### PR TITLE
Update ExtioNickTrackerVer5.63.kvs

### DIFF
--- a/ExScripts-NickTracker/ExtioNickTrackerVer5.63.kvs
+++ b/ExScripts-NickTracker/ExtioNickTrackerVer5.63.kvs
@@ -75,7 +75,7 @@ alias(NT::NickTrackerProcess)
 {
 	%NTSet = $config.open(NickTrackerSettings.kvs) ;
 	%nOfN = $config.read(%NTSet,NickNum,6) ;
-	%ntUserDisplay = $config.read(%NTSet,NTdisplayUser,"on");
+	%ntUserDisplay = $config.read(%NTSet,NTdisplayUser,"off");
 	%ntIpDisplay = $config.read(%NTSet,NTdisplayIp,"on");
 	%powerstate = $config.read(%NTSet,NTpower,"on")
 	config.close %NTSet ; 


### PR DESCRIPTION
disable username display by default, changed from on to off. 
useful for networks like jesusrocksonirc where most usernames correspond with pc being used, not useful for networks where most everyone has a default username, like kvirc channel.
